### PR TITLE
Improve student activity registration system

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Remove a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball league and practice",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Learn tennis skills and compete in friendly matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 10,
+        "participants": ["lucas@mergington.edu", "maya@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["isabella@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting, improvisation, and theatrical performances",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["noah@mergington.edu", "ava@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and critical thinking skills",
+        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["sophia@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific concepts",
+        "schedule": "Fridays, 4:00 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["ethan@mergington.edu", "grace@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    #validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -10,8 +10,9 @@ document.addEventListener("DOMContentLoaded", () => {
       const response = await fetch("/activities");
       const activities = await response.json();
 
-      // Clear loading message
+      // Clear existing content before repopulating
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,27 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsMarkup = details.participants
+          .map(
+            (participant) => `
+            <li>
+              <button class="remove-btn" data-activity="${name}" data-email="${participant}" title="Unregister participant">&#x1F5D1;</button>
+              <span>${participant}</span>
+            </li>`
+          )
+          .join("");
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants (${details.participants.length}):</strong></p>
+            <ul class="participants-list">
+              ${participantsMarkup}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +78,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +95,31 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle participant removal
+  activitiesList.addEventListener("click", async (event) => {
+    const btn = event.target.closest(".remove-btn");
+    if (!btn) return;
+
+    const activity = btn.dataset.activity;
+    const email = btn.dataset.email;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      if (response.ok) {
+        fetchActivities();
+      } else {
+        const result = await response.json();
+        alert(result.detail || "Failed to remove participant.");
+      }
+    } catch (error) {
+      console.error("Error removing participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,50 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding: 12px;
+  background: linear-gradient(180deg, #ffffff 0%, #f1f5ff 100%);
+  border: 1px solid #d7e0ff;
+  border-radius: 8px;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #243b7a;
+}
+
+.participants-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  color: #324155;
+}
+
+.remove-btn {
+  background: none;
+  border: none;
+  padding: 0 2px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #c62828;
+  border-radius: 4px;
+  line-height: 1;
+  transition: background-color 0.15s, transform 0.1s;
+}
+
+.remove-btn:hover {
+  background-color: #ffebee;
+  transform: scale(1.2);
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,96 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset in-memory activity state before each test."""
+    original = {name: {**data, "participants": list(data["participants"])} for name, data in activities.items()}
+    yield
+    activities.clear()
+    activities.update(original)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, follow_redirects=False)
+
+
+# ---------------------------------------------------------------------------
+# GET /
+# ---------------------------------------------------------------------------
+
+def test_root_redirects(client):
+    response = client.get("/")
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+# ---------------------------------------------------------------------------
+# GET /activities
+# ---------------------------------------------------------------------------
+
+def test_get_activities_returns_all(client):
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    assert len(data) == 9
+    assert "Chess Club" in data
+
+
+def test_get_activities_shape(client):
+    response = client.get("/activities")
+    chess = response.json()["Chess Club"]
+    assert "description" in chess
+    assert "schedule" in chess
+    assert "max_participants" in chess
+    assert "participants" in chess
+
+
+# ---------------------------------------------------------------------------
+# POST /activities/{activity_name}/signup
+# ---------------------------------------------------------------------------
+
+def test_signup_success(client):
+    response = client.post("/activities/Chess Club/signup?email=new@mergington.edu")
+    assert response.status_code == 200
+    assert "new@mergington.edu" in response.json()["message"]
+    assert "new@mergington.edu" in activities["Chess Club"]["participants"]
+
+
+def test_signup_unknown_activity(client):
+    response = client.post("/activities/Unknown Activity/signup?email=new@mergington.edu")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_duplicate(client):
+    client.post("/activities/Chess Club/signup?email=new@mergington.edu")
+    response = client.post("/activities/Chess Club/signup?email=new@mergington.edu")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /activities/{activity_name}/signup
+# ---------------------------------------------------------------------------
+
+def test_unregister_success(client):
+    response = client.delete("/activities/Chess Club/signup?email=michael@mergington.edu")
+    assert response.status_code == 200
+    assert "michael@mergington.edu" in response.json()["message"]
+    assert "michael@mergington.edu" not in activities["Chess Club"]["participants"]
+
+
+def test_unregister_unknown_activity(client):
+    response = client.delete("/activities/Unknown Activity/signup?email=michael@mergington.edu")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_not_enrolled(client):
+    response = client.delete("/activities/Chess Club/signup?email=nobody@mergington.edu")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not signed up for this activity"


### PR DESCRIPTION
This pull request adds new features for managing activity participants, improves the frontend display of participants, and introduces automated testing for the activity signup API. The most significant changes include support for unregistering participants, enhanced participant lists with removal controls in the UI, and comprehensive backend tests to ensure correct behavior.

**Backend functionality:**

* Added an endpoint to allow unregistering a student from an activity and validation to prevent duplicate signups or removal of non-participants (`src/app.py`).
* Expanded the in-memory `activities` data with several new activities for more comprehensive testing and demo purposes (`src/app.py`).

**Frontend improvements:**

* Updated the UI to display participant lists for each activity, including a remove button next to each participant, and implemented logic to handle participant removal via the new backend endpoint (`src/static/app.js`, `src/static/styles.css`). [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L13-R43) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R101-R125) [[3]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R120)
* Improved the activity list refresh logic after signup or removal to keep the UI in sync with backend changes (`src/static/app.js`).

**Testing and configuration:**

* Added a comprehensive test suite covering activity listing, signup, duplicate prevention, and unregistering, with fixtures to reset activity state between tests (`tests/test_app.py`).
* Configured pytest to automatically discover tests in the `tests` directory (`pytest.ini`).